### PR TITLE
P25 json fix

### DIFF
--- a/opt/Analog_Reflector/arRoot/modes/P25_node_list.json
+++ b/opt/Analog_Reflector/arRoot/modes/P25_node_list.json
@@ -25,7 +25,7 @@
     { "disp": "Australia NSW Bridge to AU NSW YSF", "tg": "10700" },
     { "disp": "Austria", "tg": "23255" },
     { "disp": "Russia P25 Net", "tg": "25641" },
-    { "disp": "America-Ragchew= 28299" },
+    { "disp": "America-Ragchew", "tg": "28299" },
     { "disp": "NorCal-Bridge / Multimode-P25-TG30639", "tg": "30639" },
     { "disp": "Alabama Link", "tg": "31010" },
     { "disp": "Mountain West", "tg": "31062" },


### PR DESCRIPTION
Fixed tg typo with p25 mode json file.....

    { "disp": "America-Ragchew", "tg": "28299" }, 
    
had an equal sign in the line.